### PR TITLE
fix return values for pam_get_user & pam_get_authtok

### DIFF
--- a/pam_ldapdb.cpp
+++ b/pam_ldapdb.cpp
@@ -93,13 +93,17 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh,
 {
     const char* user;
     const char* pass;
+    int ret;
     ArgMap arguments = get_args(argc, argv);
 
-    if (pam_get_user(pamh, &user, NULL) != PAM_SUCCESS) {
-        return PAM_AUTH_ERR;
+    ret = pam_get_user(pamh, &user, NULL);
+    if (ret != PAM_SUCCESS) {
+        return ret;
     }
-    if (pam_get_authtok(pamh, PAM_AUTHTOK, &pass, NULL) != PAM_SUCCESS) {
-        return PAM_AUTH_ERR;
+
+    ret = pam_get_authtok(pamh, PAM_AUTHTOK, &pass, NULL);
+    if (ret != PAM_SUCCESS) {
+        return ret;
     }
 
     // ensure uri and binddn PAM parameters were specified


### PR DESCRIPTION
As pam_get_{user,authtok} return valid PAM return values use them
instead of the generic PAM_AUTH_ERR.

Signed-off-by: Richard Leitner <richard.leitner@skidata.com>